### PR TITLE
update nightly code and add allocator-api2 support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,9 @@ azure-devops = { project = "alecmocatta/cap", pipeline = "tests" }
 maintenance = { status = "passively-maintained" }
 
 [features]
-nightly = []
+default = []
+nightly = ["allocator-api2?/nightly"]
 stats = []
 
 [dependencies]
+allocator-api2 = { version = "0.2", optional = true }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -454,7 +454,10 @@ mod tests {
 			let mut vec2 = Vec::<u8, _>::with_capacity_in(0, &A);
 			assert!(vec2.try_reserve_exact(1).is_err());
 		}
-		assert_eq!(A.max_allocated(), allocate_amount + allocated);
-		assert!(A.total_allocated() >= allocated + (10 * allocate_amount));
+		#[cfg(feature = "stats")]
+		{
+			assert!(A.total_allocated() >= allocated + (10 * allocate_amount));
+			assert_eq!(A.max_allocated(), allocate_amount + allocated);
+		}
 	}
 }


### PR DESCRIPTION
- Added `allocator-api2` as optional dependency
- Fix Allocator implementation for latest nightly rust
- Fix test for nightly / allocator api
  - use `Vec::with_capacity_in` instead of rely on global allocator